### PR TITLE
Check input bioequivalence

### DIFF
--- a/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindow.py
+++ b/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindow.py
@@ -37,9 +37,10 @@ class WrappedDownloadWindow(DownloadWindow, QtWidgets.QMainWindow):
             msg.setInformativeText('Выберите файл')
             msg.setWindowTitle("Ошибка")
             msg.exec_()
+            
+            return
 
-        while self.settings['path_test'] != '' and self.settings['path_ref'] != '' \
-            and (check_group_column(self.settings['path_test'])\
+        while (check_group_column(self.settings['path_test'])\
             or check_group_column(self.settings['path_ref'])):
             msg = QMessageBox()
             msg.setIcon(QMessageBox.Warning)

--- a/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindow.py
+++ b/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindow.py
@@ -4,6 +4,8 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import (
     QWidget, QToolTip, QPushButton, QApplication, QMessageBox, )
 
+from GUI.apps.utils import check_group_column
+
 from .DownloadWindow import DownloadWindow
 
 
@@ -36,7 +38,18 @@ class WrappedDownloadWindow(DownloadWindow, QtWidgets.QMainWindow):
             msg.setWindowTitle("Ошибка")
             msg.exec_()
 
+        while self.settings['path_test'] != '' and self.settings['path_ref'] != '' \
+            and (check_group_column(self.settings['path_test'])\
+            or check_group_column(self.settings['path_ref'])):
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
+            msg.setText("Ошибка")
+            msg.setInformativeText('Выберите файл правильно')
+            msg.setWindowTitle("Ошибка")
+            msg.exec_()
+
             return
+
         with open('settings.py', 'rb') as f:
             data = pickle.load(f)
             data['MODULE_SETTINGS'].update(self.settings)

--- a/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
+++ b/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
@@ -52,8 +52,7 @@ class WrappedDownloadWindowCross(DownloadWindowCross, QtWidgets.QMainWindow):
             return
         
 
-        while self.settings['path_test'] != '' and self.settings['path_ref'] != '' \
-            and (check_first_group_cross(self.settings['path_test']) != 'T' \
+        while (check_first_group_cross(self.settings['path_test']) != 'T' \
             or check_first_group_cross(self.settings['path_ref']) != 'R'):
             msg = QMessageBox()
             msg.setIcon(QMessageBox.Warning)

--- a/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
+++ b/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
@@ -4,6 +4,8 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import (
     QWidget, QToolTip, QPushButton, QApplication, QMessageBox, )
 
+from GUI.apps.utils import check_first_group_cross
+
 from .DownloadWindowCross import DownloadWindowCross
 
 
@@ -33,6 +35,18 @@ class WrappedDownloadWindowCross(DownloadWindowCross, QtWidgets.QMainWindow):
             msg.setIcon(QMessageBox.Warning)
             msg.setText("Ошибка")
             msg.setInformativeText('Выберите файл')
+            msg.setWindowTitle("Ошибка")
+            msg.exec_()
+
+            return
+
+        while self.settings['path_test'] != '' and self.settings['path_ref'] != '' \
+            and (check_first_group_cross(self.settings['path_test']) != 'T' \
+            or check_first_group_cross(self.settings['path_ref']) != 'R'):
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
+            msg.setText("Ошибка")
+            msg.setInformativeText('Выберите файлы правильно')
             msg.setWindowTitle("Ошибка")
             msg.exec_()
 

--- a/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
+++ b/SmartMedApp/GUI/apps/BioequivalenceApp/WrappedDownloadWindowCross.py
@@ -4,7 +4,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtWidgets import (
     QWidget, QToolTip, QPushButton, QApplication, QMessageBox, )
 
-from GUI.apps.utils import check_first_group_cross
+from GUI.apps.utils import check_first_group_cross, check_group_column
 
 from .DownloadWindowCross import DownloadWindowCross
 
@@ -40,6 +40,18 @@ class WrappedDownloadWindowCross(DownloadWindowCross, QtWidgets.QMainWindow):
 
             return
 
+        while ~check_group_column(self.settings['path_test'])\
+            or ~check_group_column(self.settings['path_ref']):
+            msg = QMessageBox()
+            msg.setIcon(QMessageBox.Warning)
+            msg.setText("Ошибка")
+            msg.setInformativeText('Выберите файл правильно')
+            msg.setWindowTitle("Ошибка")
+            msg.exec_()
+
+            return
+        
+
         while self.settings['path_test'] != '' and self.settings['path_ref'] != '' \
             and (check_first_group_cross(self.settings['path_test']) != 'T' \
             or check_first_group_cross(self.settings['path_ref']) != 'R'):
@@ -51,6 +63,7 @@ class WrappedDownloadWindowCross(DownloadWindowCross, QtWidgets.QMainWindow):
             msg.exec_()
 
             return
+
         with open('settings.py', 'rb') as f:
             data = pickle.load(f)
             data['MODULE_SETTINGS'].update(self.settings)

--- a/SmartMedApp/GUI/apps/utils.py
+++ b/SmartMedApp/GUI/apps/utils.py
@@ -34,3 +34,10 @@ def get_columns(path):
 		df = pd.read_csv(path)
 	return df
 
+def check_first_group_cross(path):
+	df = get_columns(path)
+	if df.loc[0, 'Group'] == 'R':
+		return 'R'
+	else:
+		return 'T'
+

--- a/SmartMedApp/GUI/apps/utils.py
+++ b/SmartMedApp/GUI/apps/utils.py
@@ -41,3 +41,10 @@ def check_first_group_cross(path):
 	else:
 		return 'T'
 
+def check_group_column(path):
+	df = get_columns(path)
+	if 'Group' in df.columns:
+		return True
+	else:
+		return False
+

--- a/SmartMedApp/backend/modules/ModuleInterface.py
+++ b/SmartMedApp/backend/modules/ModuleInterface.py
@@ -12,7 +12,6 @@ class Module(ABC):
 
         # get settings['MODULE_SETTINGS']
         self.settings = settings
-        print(settings)
 
         # call dash.Dashboard __init__ to create Dashboard object
         super().__init__()

--- a/SmartMedApp/backend/modules/ModuleInterface.py
+++ b/SmartMedApp/backend/modules/ModuleInterface.py
@@ -12,6 +12,7 @@ class Module(ABC):
 
         # get settings['MODULE_SETTINGS']
         self.settings = settings
+        print(settings)
 
         # call dash.Dashboard __init__ to create Dashboard object
         super().__init__()


### PR DESCRIPTION
Проверка правильного выбора файлов Биоэквивалентности. Перекрестный дизайн проверяется по первой записанной группе(в документации не регламентируется, что если файл TR, то первая указанная группа - это T, но в датасетах именно так). Пользователь получает уведомление о неправильном выборе файлов. Не делал замену двух файлов, так как пользователь может выбрать два одинаковых или вовсе не из перекрестного дизайна.

Перекрестный и параллельный дизайн проверяется на передачу файлов из другого дизайна посредством проверки наличия колонки Groups

Проверить правильность R и T в параллельном дизайне не предоставляется возможным